### PR TITLE
Fixes small options bug

### DIFF
--- a/src/Drizzle.js
+++ b/src/Drizzle.js
@@ -87,7 +87,8 @@ class Drizzle {
     for (var i = 0; i < this.options.contracts.length; i++)
     {
       const contractArtifact = this.options.contracts[i]
-      const events = contractArtifact.contractName in this.options.events ? this.options.events[contractArtifact.contractName] : []
+
+      const events = this.options.events && contractArtifact.contractName in this.options.events ? this.options.events[contractArtifact.contractName] : []
 
       this.contracts[contractArtifact.contractName] = new DrizzleContract(contractArtifact, web3, store, events)
     }


### PR DESCRIPTION
```
const events = contractArtifact.contractName in this.options.events ? this.options.events[contractArtifact.contractName] : []
```
If the user doesn't specify an events key, the "in" function will throw an error.

I don't actually know how to test this, but I think this is the gist of the fix.