### PR TITLE
Add an option to ignore metamask

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Drizzle is a collection of front-end libraries that make writing dapp frontends 
     ]
   },
   web3: {
+    ignoreMetamask, 
     fallback: {
       type
       url
@@ -118,6 +119,9 @@ An object consisting of contract names each containing an array of strings of th
 
 ### `web3` (object)
 Options regarding `web3` instantiation.
+
+#### `ignoreMetamask` (Boolean)
+If true Drizzle will ignore any injected web3 provider (including Metamask) that is present in the window context. Defaults to false. 
 
 #### `fallback` (object)
 An object consisting of the type and url of a fallback web3 provider. This is used if no injected provider, such as MetaMask or Mist, is detected.

--- a/src/Drizzle.js
+++ b/src/Drizzle.js
@@ -31,8 +31,14 @@ class Drizzle {
   getWeb3() {
     this.store.dispatch({type: 'WEB3_INITIALIZING'})
 
+    // Check if we are going to ignore metamask 
+    const ignoreMetamask = ('ignoreMetamask' in this.options.web3) ? 
+          this.options.web3.ignoreMetamask : 
+          false
+
     // Checking if Web3 has been injected by the browser (Mist/MetaMask)
-    if (typeof window.web3 !== 'undefined') {
+    if (typeof window.web3 !== 'undefined' && !ignoreMetamask) {
+
       // Use Mist/MetaMask's provider.
       this.web3 = new Web3(window.web3.currentProvider)
 


### PR DESCRIPTION
Drizzle is not working with the current verions of web3 and Metamask due the the metamask providers lack of support for websockets. 

As a workaround, this change adds an option to tell Drizzle to ignore metamask (or any injected web3 library) and use its fallback provider. 

By using this option, developes Dapp developers can use Metamask directly to send any transactions that require gas or ether, while using Drizzle to monitor changes to the contract state and events