### PR TITLE
Indexing contracts per address rather than by name

### DIFF
--- a/src/Drizzle.js
+++ b/src/Drizzle.js
@@ -89,7 +89,7 @@ class Drizzle {
       const contractArtifact = this.options.contracts[i]
       const events = contractArtifact.contractName in this.options.events ? this.options.events[contractArtifact.contractName] : []
 
-      this.contracts[contractArtifact.contractName] = new DrizzleContract(contractArtifact, web3, store, events)
+      new DrizzleContract(contractArtifact, web3, store, events)
     }
 
     // Wait until all contracts are intialized before observing changes
@@ -155,9 +155,9 @@ class Drizzle {
               if (contractAddresses.indexOf(txs[i].from) !== -1 || contractAddresses.indexOf(txs[i].to) !== -1)
               {
                 const index = contractAddresses.indexOf(txs[i].from) !== -1 ? contractAddresses.indexOf(txs[i].from) : contractAddresses.indexOf(txs[i].to)
-                const contractName = contractNames[index]
+                const contractAddress = contractAddresses[index]
 
-                return this.store.dispatch({type: 'CONTRACT_SYNCING', contract: this.contracts[contractName]})
+                return this.store.dispatch({type: 'CONTRACT_SYNCING', contract: this.contracts[contractAddress]})
               }
             }
           }

--- a/src/Drizzle.js
+++ b/src/Drizzle.js
@@ -16,6 +16,7 @@ class Drizzle {
     // Function Bindings
     this.getWeb3 = this.getWeb3.bind(this)
     this.getAccounts = this.getAccounts.bind(this)
+    this.addContract = this.addContract.bind(this)
     this.getContracts = this.getContracts.bind(this)
     this.observeBlocks = this.observeBlocks.bind(this)
 
@@ -79,20 +80,25 @@ class Drizzle {
     })
   }
 
-  getContracts() {
+  addContract(contractArtifact, events) {
     var store = this.store
     var web3 = this.web3
+    new DrizzleContract(contractArtifact, web3, store, events)
+  }
+
+  getContracts() {
+    var store = this.store
 
     // Get all JSON artifacts passed in by user, instantiating and storing each contract.
     for (var i = 0; i < this.options.contracts.length; i++)
     {
       const contractArtifact = this.options.contracts[i]
       const events = contractArtifact.contractName in this.options.events ? this.options.events[contractArtifact.contractName] : []
-
-      new DrizzleContract(contractArtifact, web3, store, events)
+      this.addContract(contractArtifact, events)
     }
 
     // Wait until all contracts are intialized before observing changes
+    // (julien) Is that still needed? Probably not...
     this.readytoObserve = store.subscribe(() => {
       const state = store.getState()
       var initializedContracts = 0

--- a/src/Drizzle.js
+++ b/src/Drizzle.js
@@ -93,7 +93,7 @@ class Drizzle {
   addContract(contractArtifact, address, events) {
     var store = this.store
     var web3 = this.web3
-    new DrizzleContract(contractArtifact, address, web3, store, events)
+    return new DrizzleContract(contractArtifact, address, web3, store, events)
   }
 
   getContracts() {

--- a/src/DrizzleContract.js
+++ b/src/DrizzleContract.js
@@ -10,9 +10,9 @@ class DrizzleContract {
     var networkId = 0
 
     // Instantiate the contract.
-    web3.eth.net.getId()
+    this.web3.eth.net.getId()
     .then((networkId) => {
-      var web3Contract = new web3.eth.Contract(
+      var web3Contract = new this.web3.eth.Contract(
         this.abi,
         this.contractArtifact.networks[networkId].address,
         {

--- a/src/DrizzleContract.js
+++ b/src/DrizzleContract.js
@@ -24,9 +24,17 @@ class DrizzleContract {
       // Merge web3 contract instance into DrizzleContract instance.
       Object.assign(this, web3Contract)
 
+      // Constant getters
+      // for (var i2 = 0; i2 < this.abi.length; i2++) {
+      //   var item = this.abi[i2];
+
+      //   if (item.type == "function" && item.constant === true) {
+      //     contractsInitialState[contractName][item.name] = { }
+      //   }
+      // }
+
       for (var i = 0; i < this.abi.length; i++) {
         var item = this.abi[i]
-
         if (item.type == "function" && item.constant === true) {
           this.methods[item.name].cacheCall = this.cacheCallFunction(item.name, i)
         }

--- a/src/DrizzleContract.js
+++ b/src/DrizzleContract.js
@@ -19,18 +19,10 @@ class DrizzleContract {
     // Merge web3 contract instance into DrizzleContract instance.
     Object.assign(this, web3Contract)
 
-    // Constant getters
-    // for (var i2 = 0; i2 < this.abi.length; i2++) {
-    //   var item = this.abi[i2];
-
-    //   if (item.type == "function" && item.constant === true) {
-    //     contractsInitialState[contractName][item.name] = { }
-    //   }
-    // }
-
     for (var i = 0; i < this.abi.length; i++) {
       var item = this.abi[i]
       if (item.type == "function" && item.constant === true) {
+        this[item.name] = { }
         this.methods[item.name].cacheCall = this.cacheCallFunction(item.name, i)
       }
 

--- a/src/DrizzleContract.js
+++ b/src/DrizzleContract.js
@@ -60,12 +60,12 @@ class DrizzleContract {
       if (args.length > 0) {
         argsHash = contract.generateArgsHash(args)
       }
-      const contractName = contract.name
-      const functionState = contract.store.getState().contracts[contractName][fnName]
+      const contractAddress = contract.address
+      const functionState = contract.store.getState().contracts[contractAddress][fnName]
 
       // If call result is in state and fresh, return value instead of calling
       if (argsHash in functionState) {
-        if (contract.store.getState().contracts[contractName].synced === true) {
+        if (contract.store.getState().contracts[contractAddress].synced === true) {
           return argsHash
         }
       }

--- a/src/DrizzleContract.js
+++ b/src/DrizzleContract.js
@@ -5,6 +5,8 @@ class DrizzleContract {
     this.web3 = web3
     this.store = store
 
+    store.dispatch({ type: 'CONTRACT_ADDED', contract: this })
+
     var networkId = 0
 
     // Instantiate the contract.
@@ -45,7 +47,7 @@ class DrizzleContract {
 
       const name = contractArtifact.contractName
 
-      store.dispatch({type: 'CONTRACT_INITIALIZED', name})
+      store.dispatch({ type: 'CONTRACT_INITIALIZED', contract: this})
 
       return networkId
     })
@@ -102,11 +104,11 @@ class DrizzleContract {
       // TODO: FOR DEMO, MOVE MOVE MOVE
       //const name = contract.contractArtifact.contractName
       //contract.store.dispatch({type: 'CONTRACT_SYNC_IND', contractName: name})
-      
+
       // Dispatch tx to saga
       // When txhash received, will be value of stack ID
       contract.store.dispatch({type: 'SEND_CONTRACT_TX', contract, fnName, fnIndex, args, stackId})
-     
+
       // return stack ID
       return stackId
     }

--- a/src/contracts/contractsReducer.js
+++ b/src/contracts/contractsReducer.js
@@ -21,12 +21,11 @@ const contractsReducer = (state = initialState, action) => {
 
   if (action.type === 'CONTRACT_SYNCING')
   {
-    const contractName = action.contract.contractArtifact.contractName
-
+    const contractAddress = action.contract.options.address
     return {
       ...state,
-      [contractName]: {
-        ...state[contractName],
+      [contractAddress]: {
+        ...state[contractAddress],
         synced: false
       }
     }
@@ -36,8 +35,8 @@ const contractsReducer = (state = initialState, action) => {
   {
     return {
       ...state,
-      [action.contractName]: {
-        ...state[action.contractName],
+      [action.contractAddress]: {
+        ...state[action.contractAddress],
         synced: true
       }
     }
@@ -47,8 +46,8 @@ const contractsReducer = (state = initialState, action) => {
   {
     return {
       ...state,
-      [action.contractName]: {
-        ...state[action.contractName],
+      [action.contractAddress]: {
+        ...state[action.contractAddress],
         synced: false
       }
     }
@@ -62,12 +61,12 @@ const contractsReducer = (state = initialState, action) => {
   {
     return {
       ...state,
-      [action.name]: {
-        ...state[action.name],
+      [action.contractAddress]: {
+        ...state[action.contractAddress],
         [action.variable]: {
-          ...state[action.name][action.variable],
+          ...state[action.contractAddress][action.variable],
           [action.argsHash]: {
-            ...state[action.name][action.variable][action.argsHash],
+            ...state[action.contractAddress][action.variable][action.argsHash],
             args: action.args,
             fnIndex: action.fnIndex,
             value: action.value
@@ -81,12 +80,12 @@ const contractsReducer = (state = initialState, action) => {
   {
     return {
       ...state,
-      [action.name]: {
-        ...state[action.name],
+      [action.contractAddress]: {
+        ...state[action.contractAddress],
         [action.variable]: {
-          ...state[action.name][action.variable],
+          ...state[action.contractAddress][action.variable],
           [action.argsHash]: {
-            ...state[action.name][action.variable][action.argsHash],
+            ...state[action.contractAddress][action.variable][action.argsHash],
             args: action.args,
             fnIndex: action.fnIndex,
             error: action.error
@@ -104,10 +103,10 @@ const contractsReducer = (state = initialState, action) => {
   {
     return {
       ...state,
-      [action.name]: {
-        ...state[action.name],
+      [action.contractAddress]: {
+        ...state[action.contractAddress],
         events: [
-          ...state[action.name].events,
+          ...state[action.contractAddress].events,
           action.event
         ]
       }

--- a/src/contracts/contractsReducer.js
+++ b/src/contracts/contractsReducer.js
@@ -9,7 +9,7 @@ const contractsReducer = (state = initialState, action) => {
   {
     return {
       ...state,
-      [action.contract.options.address]: {
+      [action.contract.address]: {
         ...action.contract,
         ...state[action.contract],
         initialized: true,
@@ -21,7 +21,7 @@ const contractsReducer = (state = initialState, action) => {
 
   if (action.type === 'CONTRACT_SYNCING')
   {
-    const contractAddress = action.contract.options.address
+    const contractAddress = action.contract.address
     return {
       ...state,
       [contractAddress]: {

--- a/src/contracts/contractsReducer.js
+++ b/src/contracts/contractsReducer.js
@@ -1,16 +1,17 @@
 const initialState = {}
 
 const contractsReducer = (state = initialState, action) => {
+
   /*
    * Contract Status
    */
-
   if (action.type === 'CONTRACT_INITIALIZED')
   {
     return {
       ...state,
-      [action.name]: {
-        ...state[action.name],
+      [action.contract.options.address]: {
+        ...action.contract,
+        ...state[action.contract],
         initialized: true,
         synced: true,
         events: []

--- a/src/contracts/contractsSaga.js
+++ b/src/contracts/contractsSaga.js
@@ -6,7 +6,7 @@ import { call, put, select, take, takeLatest, takeEvery } from 'redux-saga/effec
  */
 
 function createContractEventChannel({contract, eventName}) {
-  const contractAddress = contract.options.address
+  const contractAddress = contract.address
 
   return eventChannel(emit => {
     const eventListener = contract.events[eventName]().on('data', event => {
@@ -85,7 +85,7 @@ function* callSendContractTx({contract, fnName, fnIndex, args, stackId}) {
   }
 
   // Get address to mark as desynchronized on tx creation
-  const contractAddress = contract.options.address
+  const contractAddress = contract.address
 
   // Create the transaction object and execute the tx.
   const txObject = yield call(contract.methods[fnName], ...args)
@@ -125,7 +125,7 @@ function* callCallContractFn({contract, fnName, fnIndex, args, argsHash}) {
     const callResult = yield call(txObject.call, callArgs)
 
     var dispatchArgs = {
-      contractAddress: contract.options.contractAddress,
+      contractAddress: contract.address,
       variable: contract.abi[fnIndex].name,
       argsHash: argsHash,
       args: args,
@@ -139,7 +139,7 @@ function* callCallContractFn({contract, fnName, fnIndex, args, argsHash}) {
     console.error(error)
 
     var errorArgs = {
-      contractAddress: contract.options.address,
+      contractAddress: contract.address,
       variable: contract.abi[fnIndex].name,
       argsHash: argsHash,
       args: args,

--- a/src/contracts/contractsSaga.js
+++ b/src/contracts/contractsSaga.js
@@ -6,17 +6,17 @@ import { call, put, select, take, takeLatest, takeEvery } from 'redux-saga/effec
  */
 
 function createContractEventChannel({contract, eventName}) {
-  const name = contract.contractArtifact.contractName
+  const contractAddress = contract.options.address
 
   return eventChannel(emit => {
     const eventListener = contract.events[eventName]().on('data', event => {
-      emit({type: 'EVENT_FIRED', name, event})
+      emit({type: 'EVENT_FIRED', contractAddress, event})
     })
     .on('changed', event => {
-      emit({type: 'EVENT_CHANGED', name, event})
+      emit({type: 'EVENT_CHANGED', contractAddress, event})
     })
     .on('error', error => {
-      emit({type: 'EVENT_ERROR', name, error})
+      emit({type: 'EVENT_ERROR', contractAddress, error})
       emit(END)
     })
 
@@ -41,7 +41,7 @@ function* callListenForContractEvent({contract, eventName}) {
  * Send and Cache
  */
 
-function createTxChannel({txObject, stackId, sendArgs = {}, contractName}) {
+function createTxChannel({txObject, stackId, sendArgs = {}, contractAddress}) {
   var persistTxHash
 
   return eventChannel(emit => {
@@ -49,10 +49,10 @@ function createTxChannel({txObject, stackId, sendArgs = {}, contractName}) {
       persistTxHash = txHash
 
       emit({type: 'TX_BROADCASTED', txHash, stackId})
-      emit({type: 'CONTRACT_SYNC_IND', contractName})
+      emit({type: 'CONTRACT_SYNC_IND', contractAddress})
     })
     .on('confirmation', (confirmationNumber, receipt) => {
-      emit({type: 'TX_CONFIRMAITON', confirmationReceipt: receipt, txHash: persistTxHash})
+      emit({type: 'TX_CONFIRMATION', confirmationReceipt: receipt, txHash: persistTxHash})
     })
     .on('receipt', receipt => {
       emit({type: 'TX_SUCCESSFUL', receipt: receipt, txHash: persistTxHash})
@@ -84,12 +84,12 @@ function* callSendContractTx({contract, fnName, fnIndex, args, stackId}) {
     args.length = args.length - 1
   }
 
-  // Get name to mark as desynchronized on tx creation
-  const contractName = contract.contractArtifact.contractName
+  // Get address to mark as desynchronized on tx creation
+  const contractAddress = contract.options.address
 
   // Create the transaction object and execute the tx.
   const txObject = yield call(contract.methods[fnName], ...args)
-  const txChannel = yield call(createTxChannel, {txObject, stackId, sendArgs, contractName})
+  const txChannel = yield call(createTxChannel, {txObject, stackId, sendArgs, contractAddress})
 
   try {
     while (true) {
@@ -117,36 +117,36 @@ function* callCallContractFn({contract, fnName, fnIndex, args, argsHash}) {
     delete args[args.length - 1]
     args.length = args.length - 1
   }
-  
+
   // Create the transaction object and execute the call.
   const txObject = yield call(contract.methods[fnName], ...args)
-  
+
   try {
     const callResult = yield call(txObject.call, callArgs)
 
     var dispatchArgs = {
-      name: contract.contractArtifact.contractName,
+      contractAddress: contract.options.contractAddress,
       variable: contract.abi[fnIndex].name,
       argsHash: argsHash,
       args: args,
       value: callResult,
       fnIndex: fnIndex
     }
-  
-    yield put({type: 'GOT_CONTRACT_VAR', ...dispatchArgs})  
+
+    yield put({type: 'GOT_CONTRACT_VAR', ...dispatchArgs})
   }
   catch (error) {
     console.error(error)
 
     var errorArgs = {
-      name: contract.contractArtifact.contractName,
+      contractAddress: contract.options.address,
       variable: contract.abi[fnIndex].name,
       argsHash: argsHash,
       args: args,
       error: error,
       fnIndex: fnIndex
     }
-  
+
     yield put({type: 'ERROR_CONTRACT_VAR', ...errorArgs})
   }
 }

--- a/src/generateStore.js
+++ b/src/generateStore.js
@@ -9,33 +9,9 @@ function generateStore(options) {
   // Redux DevTools
   const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-  // Preloaded state
-  var contractsInitialState = {}
-
-  for (var i = 0; i < options.contracts.length; i++)
-  {
-    // Initial contract details
-    var contractName = options.contracts[i].contractName
-
-    contractsInitialState[contractName] = {
-      initialized: false,
-      synced: false
-    }
-
-    // Constant getters
-    for (var i2 = 0; i2 < options.contracts[i].abi.length; i2++) {
-      var item = options.contracts[i].abi[i2];
-
-      if (item.type == "function" && item.constant === true) {
-        contractsInitialState[contractName][item.name] = {}
-      }
-    }
-
-  }
-
   var preloadedState = {
     accounts: {},
-    contracts: contractsInitialState,
+    contracts: {},
     //web3: {}
   }
 

--- a/src/transactions/transactionsReducer.js
+++ b/src/transactions/transactionsReducer.js
@@ -1,5 +1,5 @@
 const initialState = {}
-  
+
 const transactionsReducer = (state = initialState, action) => {
     if (action.type === 'TX_BROADCASTED')
     {
@@ -12,7 +12,7 @@ const transactionsReducer = (state = initialState, action) => {
         }
     }
 
-    if (action.type === 'TX_CONFIRMAITON')
+    if (action.type === 'TX_CONFIRMATION')
     {
         return {
             ...state,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ const path = require('path');
 process.env.BABEL_ENV = 'production';
 
 module.exports = {
+  watch: true,
   entry: './src/index.js',
   output: {
     filename: 'drizzle.js',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const path = require('path');
 process.env.BABEL_ENV = 'production';
 
 module.exports = {
-  watch: true,
+  // watch: true,
   entry: './src/index.js',
   output: {
     filename: 'drizzle.js',


### PR DESCRIPTION
I believe this is a more flexible approach because a dapp could point to multiple contracts of the same name but with different addresses.
This PR also includes the ability to add a contract later one (using its `contractArtifact` and `address`, which I believe is what #9 is about).

I am not sure how to make sure everything else is still working the same though, but my app which used the older version of drizzle works with this ;)