### PR TITLE
Fix number type args

### DIFF
--- a/src/DrizzleContract.js
+++ b/src/DrizzleContract.js
@@ -110,6 +110,11 @@ class DrizzleContract {
           argToHash = JSON.stringify(argToHash)
         }
 
+        // Convert number to strong to allow hashing
+        if (typeof argToHash === 'number') {
+          argToHash = argToHash.toString()
+        }
+
         // This check is in place for web3 v0.x
         if ('utils' in web3) {
           var hashPiece = web3.utils.sha3(argToHash)


### PR DESCRIPTION
Currently when trying to call a method with a number argument it results in this error:
```
uncaught at callCallContractFn TypeError: str.slice is not a function
    at Object.keccak256 (http://localhost:3000/static/js/bundle.js:60916:14)
    at Object.sha3 (http://localhost:3000/static/js/bundle.js:60553:29)
    at DrizzleContract.generateArgsHash (http://localhost:3000/static/js/bundle.js:69699:39)
```
This PR converts the number arg to a string so that it can be hashed properly.
