### PR TITLE
Renamed push to stack action to match name in reducer

### DIFF
--- a/src/DrizzleContract.js
+++ b/src/DrizzleContract.js
@@ -101,7 +101,7 @@ class DrizzleContract {
       var stackId = contract.store.getState().transactionStack.length
 
       // Add ID to "transactionStack" with empty value
-      contract.store.dispatch({ type: 'PUSH_TO_STACK' })
+      contract.store.dispatch({type: 'PUSH_TO_TXSTACK'})
 
       // Dispatch tx to saga
       // When txhash received, will be value of stack ID


### PR DESCRIPTION
Push to stack action was not updating state. This was because of a naming mismatch between dispatched action and the name in the reducer (PUSH_TO_STACK vs PUSH_TO_TXSTACK).