### PR TITLE
Fix readme for addContract function

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ events = ['Mint']
 dispatch({type: 'ADD_CONTRACT', drizzle, contractConfig, events, web3})
 
 // Or using the Drizzle context object
-this.context.drizzle.addContract({contractConfig, events})
+this.context.drizzle.addContract(contractConfig, events)
 ```
 
 ## Options


### PR DESCRIPTION
The addContract function expects 'contractConfig' and 'events' as the first and second argument, while the readme instructs to pass them in an object.

Related to #82.