### PR TITLE
Ganache provider vs server

### DIFF
--- a/test/accountBalances.test.js
+++ b/test/accountBalances.test.js
@@ -7,10 +7,10 @@ let dispatchedActions;
 let store;
 
 beforeAll(() => {
-  web3 = new Web3('ws://127.0.0.1:8545');
+  web3 = new Web3(global.provider);
 
   dispatchedActions = [];
-  store = {
+  store = { 
     getState: () => ({
       accounts: [
         '0x8adb46251e9cd45b5027501766531825c04a2e06'

--- a/test/accounts.test.js
+++ b/test/accounts.test.js
@@ -7,7 +7,7 @@ let dispatchedActions;
 let store;
 
 beforeAll(() => {
-  web3 = new Web3('ws://127.0.0.1:8545');
+  web3 = new Web3(global.provider);
 
   dispatchedActions = [];
   store = {

--- a/test/blocks.test.js
+++ b/test/blocks.test.js
@@ -10,7 +10,7 @@ let interval;
 let blockPoller;
 
 beforeAll(() => {
-  web3 = new Web3('ws://127.0.0.1:8545');
+  web3 = new Web3(global.provider);
   drizzle = {};
   syncAlways = false;
   interval = 100;

--- a/test/environments/ganache-environment.js
+++ b/test/environments/ganache-environment.js
@@ -2,8 +2,6 @@ let Web3 = require('web3');
 const Ganache = require('ganache-cli');
 const NodeEnvironment = require('jest-environment-node');
 
-let server;
-
 class GanacheEnvironment extends NodeEnvironment {
   constructor(config) {
     super(config);
@@ -13,17 +11,7 @@ class GanacheEnvironment extends NodeEnvironment {
     await super.setup();
 
     // Startup a Ganache server.
-    server = Ganache.server({seed: "drizzle", network_id: 6777, gasLimit: 7000000});
-    server.listen(8545, function(err, blockchain) {
-      if (err) {
-        console.error(err);
-      }
-    });
-  }
-  
-  async teardown() {
-    server.close();
-    await super.teardown();
+    this.global.provider = Ganache.provider({seed: "drizzle", network_id: 6777, gasLimit: 7000000});
   }
 }
 

--- a/test/web3.test.js
+++ b/test/web3.test.js
@@ -1,17 +1,18 @@
 import { initializeWeb3, getNetworkId } from '../src/web3/web3Saga';
 import { runSaga } from 'redux-saga'
+import Web3 from 'web3';
 
 global.window = {};
 
 let dispatchedActions;
 let store;
 let web3;
-const options = {
+/*const options = {
   fallback: {
     type: 'ws',
     url: 'ws://127.0.0.1:8545'
   }
-};
+};*/
 
 beforeAll(() => {
   dispatchedActions = [];
@@ -21,14 +22,16 @@ beforeAll(() => {
   };
 });
 
-test('get web3', async function() {
+/*test('get web3', async function() {
   web3 = await runSaga(store, initializeWeb3, { options }).done;
 
   expect(dispatchedActions[0].type).toEqual('WEB3_INITIALIZED');
-});
+});*/
 
 test('get network ID', async function() {
+  web3 = new Web3(global.provider);
+  
   await runSaga(store, getNetworkId, { web3 }).done;
 
-  expect(dispatchedActions[1].networkId).toEqual(6777);
+  expect(dispatchedActions[0].networkId).toEqual(6777);
 });


### PR DESCRIPTION
Swap out `Ganache.provider()` for `Ganache.server()` in Jest environment.