### PR TITLE
Remove unnecessary saga

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ const drizzleSagas = [
   accountBalancesSaga,
   blocksSaga,
   contractsSaga,
-  drizzleStatusSaga,
+  drizzleStatusSaga
 ]
 
 export {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,6 @@ import accountBalancesSaga from './accountBalances/accountBalancesSaga'
 import blocksSaga from './blocks/blocksSaga'
 import contractsSaga from './contracts/contractsSaga'
 import drizzleStatusSaga from './drizzleStatus/drizzleStatusSaga'
-import web3Saga from './web3/web3Saga'
 
 const drizzleSagas = [
   accountsSaga,
@@ -35,7 +34,6 @@ const drizzleSagas = [
   blocksSaga,
   contractsSaga,
   drizzleStatusSaga,
-  web3Saga
 ]
 
 export {

--- a/src/rootSaga.js
+++ b/src/rootSaga.js
@@ -5,7 +5,6 @@ import accountBalancesSaga from './accountBalances/accountBalancesSaga'
 import blocksSaga from './blocks/blocksSaga'
 import contractsSaga from './contracts/contractsSaga'
 import drizzleStatusSaga from './drizzleStatus/drizzleStatusSaga'
-import web3Saga from './web3/web3Saga'
 
 export default function * root () {
   yield all([
@@ -13,7 +12,6 @@ export default function * root () {
     fork(accountBalancesSaga),
     fork(blocksSaga),
     fork(contractsSaga),
-    fork(drizzleStatusSaga),
-    fork(web3Saga)
+    fork(drizzleStatusSaga)
   ])
 }

--- a/src/web3/web3Saga.js
+++ b/src/web3/web3Saga.js
@@ -1,4 +1,4 @@
-import { call, put, takeLatest } from 'redux-saga/effects'
+import { call, put } from 'redux-saga/effects'
 import * as Action from './constants'
 
 var Web3 = require('web3')
@@ -79,9 +79,3 @@ export function * getNetworkId ({ web3 }) {
     console.error(error)
   }
 }
-
-function * web3Saga () {
-  yield takeLatest('NETWORK_ID_FETCHING', getNetworkId)
-}
-
-export default web3Saga


### PR DESCRIPTION
web3Saga exposed an unused default function which `tookLatest`
`NETWORK_ID_FETCHING` action to kick-off a `getNetworkId` sequence. `NETWORK_ID_FETCHING` was not hooked up.
