### PR TITLE
Pin node version to v11.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js:
-  - "node"
+  - "11.10.1"
   - "--lts"
 cache: npm


### PR DESCRIPTION
Temporary solution to unblock our release.
See this SO: https://goo.gl/dpWurj

The correct solution is to update to the latest Jest, however it looks
like it may require a bump and reconfig of babel & relevant babel-plugins.

Errors after upgrading to Jest version to address fix.
```
 FAIL  test/web3.test.js
  ● Test suite failed to run

    TypeError: this.setDynamic is not a function

      at PluginPass.pre (node_modules/babel-plugin-transform-runtime/lib/index.js:31:12)
      at transformFile (node_modules/@babel/core/lib/transformation/index.js:78:27)
      at runSync (node_modules/@babel/core/lib/transformation/index.js:45:3)
      at transformSync (node_modules/@babel/core/lib/transform.js:43:38)
      at ScriptTransformer.transformSource (node_modules/@jest/transform/build/ScriptTransformer.js:367:35)
      at ScriptTransformer._transformAndBuildScript (node_modules/@jest/transform/build/ScriptTransformer.js:437:40)
      at ScriptTransformer.transform (node_modules/@jest/transform/build/ScriptTransformer.js:493:19)
```

Relevant Jest issue: https://github.com/facebook/create-react-app/issues/6591