### PR TITLE
Allows empty contracts field in options

### DIFF
--- a/src/Drizzle.js
+++ b/src/Drizzle.js
@@ -1,4 +1,6 @@
 import { generateStore } from './generateStore'
+import defaultOptions from './defaultOptions'
+import merge from './mergeOptions'
 
 // Load as promise so that async Drizzle initialization can still resolve
 var isEnvReadyPromise = new Promise((resolve, reject) => {
@@ -21,7 +23,10 @@ var isEnvReadyPromise = new Promise((resolve, reject) => {
 })
 
 class Drizzle {
-  constructor (options, store) {
+  constructor (givenOptions, store) {
+
+    const options = merge(defaultOptions, givenOptions)
+
     // Variables
     this.contracts = {}
     this.contractList = []

--- a/src/contractStateUtils.js
+++ b/src/contractStateUtils.js
@@ -19,7 +19,7 @@ export const generateContractInitialState = contractConfig => {
 }
 
 export const generateContractsInitialState = options =>
-  options.contracts.reduce((state, contract) => {
+  (options.contracts || []).reduce((state, contract) => {
     state[contract.contractName] = generateContractInitialState(contract)
     return state
   }, {})

--- a/src/drizzleStatus/drizzleStatusSaga.js
+++ b/src/drizzleStatus/drizzleStatusSaga.js
@@ -1,6 +1,4 @@
 import { call, put, select, takeLatest } from 'redux-saga/effects'
-import defaultOptions from '../defaultOptions'
-import merge from '../mergeOptions'
 
 // Initialization Functions
 import { initializeWeb3, getNetworkId } from '../web3/web3Saga'
@@ -9,7 +7,7 @@ import { getAccountBalances } from '../accountBalances/accountBalancesSaga'
 
 function * initializeDrizzle (action) {
   try {
-    const options = merge(defaultOptions, action.options)
+    const options = action.options
     const web3Options = options.web3
     const drizzle = action.drizzle
 

--- a/test/contractStateUtils.test.js
+++ b/test/contractStateUtils.test.js
@@ -86,5 +86,9 @@ describe('Contract State Utilities', () => {
         expectedStates
       )
     })
+
+    test('it generates valid initial state with empty contracts', () => {
+      expect(generateContractsInitialState({})).toEqual({})
+    })
   })
 })


### PR DESCRIPTION
This resolves #198. I have tested this against one of my dapps and it works with an empty config when it didn't before.

Some notes:

- I shifted the merging with `defaultOptions` to the earliest point so that the merged options is propogated correctly. It ensures that options will be in the desired format and downstream functions can safely assume it. If for some reason, the exact user-supplied options is required internally, I can store them in an additional field in the `Drizzle` class.

- I had to add an extra check in `generateInitialContractState` because that can be called independently of the Drizzle constructor in case one is using a custom Redux store like I was.