### PR TITLE
Fix/metamask 6.6.0 breaks access denied

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle",
-  "version": "1.4.0",
+  "version": "1.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle",
-  "version": "1.4.0",
+  "version": "1.3.3",
   "description": "A reactive data-store for web3 and smart contracts.",
   "main": "./dist/drizzle.js",
   "react-native": "./src/index.js",

--- a/src/web3/web3Saga.js
+++ b/src/web3/web3Saga.js
@@ -27,6 +27,9 @@ export function * initializeWeb3 ({ options }) {
       } catch (error) {
         // User denied account access...
         console.log(error)
+        if (typeof web3 !== 'undefined') {
+          return web3
+        }
       }
     } else if (typeof window.web3 !== 'undefined') {
       // Checking if Web3 has been injected by the browser (Mist/MetaMask)


### PR DESCRIPTION
Patch for #230 

This change allows for the same behavior to continue since before the MetaMask 6.6.0 update, where drizzle still initializes web3 but no accounts are available. This is only a patch for v1.4 as #224 introduces the WEB3_USER_DENIED status.