### PR TITLE
Fix/metamask 6.6.0 breaks access denied Rebased 1.4

### DIFF
--- a/src/web3/web3Saga.js
+++ b/src/web3/web3Saga.js
@@ -27,6 +27,12 @@ export function * initializeWeb3 ({ options }) {
       } catch (error) {
         // User denied account access...
         console.log(error)
+        if (typeof web3 !== 'undefined' || web3 !== null) {
+          yield put({ type: Action.WEB3_INITIALIZED })
+          return web3
+        }
+        // rethrow if no web3 to gracefully fail
+        throw error
       }
     } else if (typeof window.web3 !== 'undefined') {
       // Checking if Web3 has been injected by the browser (Mist/MetaMask)

--- a/test/web3.test.js
+++ b/test/web3.test.js
@@ -67,6 +67,33 @@ describe('Loads Web3', () => {
     })
   })
 
+  describe('metamask user denies access', () => {
+    let mockedEthereumEnable
+
+    beforeAll(async () => {
+      global.window = {}
+
+      // mockedEthereumEnable = jest.fn().mockImplementation(() => {throw new Error();});
+      mockedEthereumEnable = jest.fn()
+      global.provider.enable = mockedEthereumEnable
+      global.window.ethereum = global.provider
+
+      gen = initializeWeb3({ options: {} })
+    })
+
+    test('get web3', async () => {
+      let next = gen.next()
+      const error = new Error()
+      next = gen.throw(error)
+
+      expect(next.value).toEqual(put({ type: Action.WEB3_INITIALIZED }))
+
+      // is it a Web3 object?
+      resolvedWeb3 = gen.next().value
+      hasWeb3Shape(resolvedWeb3)
+    })
+  })
+
   describe('with injected web3', () => {
     beforeAll(async () => {
       global.window = {}


### PR DESCRIPTION
Patch for #230

This change allows for the same behavior to continue since before the MetaMask 6.6.0 update, where drizzle still initializes web3 but no accounts are available. This is only a patch for v1.4 as #224 introduces the WEB3_USER_DENIED status.

Supersedes #231 