### PR TITLE
Fix customProvider option

### DIFF
--- a/src/web3/web3Saga.js
+++ b/src/web3/web3Saga.js
@@ -11,8 +11,8 @@ export function * initializeWeb3 ({ options }) {
   try {
     var web3 = {}
 
-    if (options && options.web3 && options.web3.customProvider) {
-      web3 = new Web3(options.web3.customProvider)
+    if (options && options.customProvider) {
+      web3 = new Web3(options.customProvider)
       yield put({ type: Action.WEB3_INITIALIZED })
       return web3
     }

--- a/test/web3.test.js
+++ b/test/web3.test.js
@@ -17,7 +17,7 @@ describe('Resolving Web3', () => {
   describe('with customProvider', () => {
     beforeAll(async () => {
       global.window = {}
-      web3Options = { web3: { customProvider: global.provider } }
+      web3Options = { customProvider: global.provider }
     })
 
     test('get web3', async () => {


### PR DESCRIPTION
`initializeWeb3` is called with `options.web3`, so the options will look like `{ customProvider }`, not `{ web3: { customProvider } }`:

https://github.com/trufflesuite/drizzle/blob/1e869b2d7bb13aeaf33a52ba12b769aa2c391d90/src/drizzleStatus/drizzleStatusSaga.js#L13-L17